### PR TITLE
Fix leap year calculation and integer parsing

### DIFF
--- a/src/app/modules/combo-datepicker/date-utils.ts
+++ b/src/app/modules/combo-datepicker/date-utils.ts
@@ -5,7 +5,7 @@ export default class DateUtils {
   }
 
   static parseIntStrict(num) {
-    return (num !== null && num !== '' && isNaN(parseInt(num, 10))) ? parseInt(num, 10) : null;
+    return (num !== null && num !== '' && !isNaN(parseInt(num, 10))) ? parseInt(num, 10) : null;
   }
 
   static getMaxDate(month, year) {

--- a/src/app/modules/combo-datepicker/date-utils.ts
+++ b/src/app/modules/combo-datepicker/date-utils.ts
@@ -15,7 +15,7 @@ export default class DateUtils {
         res = 30;
       }
       if (year !== null && month === 2) {
-        res = ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0) ? 29 : 28;
+        res = ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0) ? 29 : 28;
       }
     }
     return res;

--- a/src/app/modules/combo-datepicker/date-utils.ts
+++ b/src/app/modules/combo-datepicker/date-utils.ts
@@ -15,7 +15,7 @@ export default class DateUtils {
         res = 30;
       }
       if (year !== null && month === 2) {
-        res = year % 4 === 0 && year % 100 !== 0 ? 29 : 28;
+        res = ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0) ? 29 : 28;
       }
     }
     return res;


### PR DESCRIPTION
This PR fixes two rather annoying bugs:

1. [`NaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN) is short for "*not* a number", so you need to validate against `!isNan()` to check if it's a number.
2. The [leap year](https://en.wikipedia.org/wiki/Leap_year#Gregorian_calendar) rules is: Every forth year, but only if not dividable by 100 but not 400. For example, the year 2000 was a leap year because it's dividable by 400. Your current code returns 28 days for the year 2000.

It would be great having those changes on NPM. Cheers!